### PR TITLE
Add fastify onClose hook, close connection when app is closing

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,14 @@ async function mongooseConnector(
     });
   }
 
+  // Close connection when app is closing
+  fastify.addHook('onClose', (app, done) => {
+    app.mongoose.instance.connection.on('close', function() {
+      done()
+    })
+    app.mongoose.instance.connection.close()
+  })
+
   fastify.decorate("mongoose", decorator);
 }
 

--- a/test.js
+++ b/test.js
@@ -137,5 +137,5 @@ tap.test("fastify.mongoose should exist", async test => {
   } catch (e) {
     test.fail("Fastify threw", e);
   }
-  fastify.mongoose.instance.connection.close();
+  fastify.close();
 });


### PR DESCRIPTION
Close connection when app is closing. With fastify onClose hook, you doesn't need to close connection with `fastify.mongoose.instance.connection.close()`. You just need `fastify.close()`