### PR TITLE
feat: ability to add simple pre and post hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,26 @@ const fixReferences = (decorator, schema) => {
   });
 };
 
+const addPreMiddleware = (schema, model) => {
+  const keys = Object.keys(model.pre);
+
+  keys.forEach((k) => {
+    if(typeof model.pre[k] === 'function') {
+      schema.pre(k, model.pre[k]);
+    }
+  });
+};
+
+const addPostMiddleware = (schema, model) => {
+  const keys = Object.keys(model.post);
+
+	keys.forEach((k) => {
+		if (typeof model.post[k] === "function") {
+			schema.post(k, model.post[k]);
+		}
+	});
+};
+
 let decorator;
 
 async function mongooseConnector(
@@ -71,6 +91,14 @@ async function mongooseConnector(
       if (model.class) schema.loadClass(model.class);
 
       if (model.virtualize) model.virtualize(schema);
+
+      if(model.pre) {
+        addPreMiddleware(schema, model);
+      }
+
+      if(model.post) {
+        addPostMiddleware(schema, model);
+      }
 
       if (useNameAndAlias) {
         /* istanbul ignore next */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-mongoose-driver",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test.js
+++ b/test.js
@@ -5,148 +5,199 @@ const tap = require("tap");
 const fastifyMongoose = require("./index");
 
 class PostClass {
-  get fullTitle() {
-    return `Title: ${this.title}`;
-  }
+	get fullTitle() {
+		return `Title: ${this.title}`;
+	}
 }
 
-tap.test("fastify.mongoose should exist", async test => {
-  test.plan(12);
+tap.test("fastify.mongoose should exist", async (test) => {
+	let hasHitPostSaveHook = false;
+	test.plan(15);
 
-  fastify.register(fastifyMongoose.plugin, {
-    uri: "mongodb://localhost:27017/test",
-    settings: {
-      useNewUrlParser: true,
-      config: {
-        autoIndex: true
-      }
-    },
-    models: [
-      {
-        name: "posts",
-        alias: "Post",
-        schema: {
-          title: {
-            type: String,
-            required: true
-          },
-          content: {
-            type: String,
-            required: true
-          },
-          author: {
-            type: "ObjectId",
-            ref: "Account",
-            validateExistance: true
-          }
-        },
-        class: PostClass
-      },
-      {
-        name: "accounts",
-        alias: "Account",
-        schema: {
-          username: {
-            type: String
-          },
-          password: {
-            type: String,
-            select: false,
-            required: true
-          },
-          email: {
-            type: String,
-            unique: true,
-            required: true,
-            validate: {
-              validator: v => {
-                // Super simple email regex: https://stackoverflow.com/a/4964763/7028187
-                return /^.+@.{2,}\..{2,}$/.test(v);
-              },
-              message: props => `${props.value} is not a valid email!`
-            }
-          },
-          posts: [
-            {
-              type: "ObjectId",
-              ref: "Post",
-              validateExistance: true
-            }
-          ],
-          createdAtUTC: {
-            type: Date,
-            required: true
-          }
-        }
-      }
-    ],
-    useNameAndAlias: true
-  });
+	fastify.register(fastifyMongoose.plugin, {
+		uri: "mongodb://localhost:27017/test",
+		settings: {
+			useNewUrlParser: true,
+			config: {
+				autoIndex: true,
+			},
+		},
+		models: [
+			{
+				name: "posts",
+				alias: "Post",
+				schema: {
+					title: {
+						type: String,
+						required: true,
+					},
+					content: {
+						type: String,
+						required: true,
+					},
+					author: {
+						type: "ObjectId",
+						ref: "Account",
+						validateExistance: true,
+					},
+				},
+				class: PostClass,
+			},
+			{
+				name: "accounts",
+				alias: "Account",
+				schema: {
+					username: {
+						type: String,
+					},
+					password: {
+						type: String,
+						select: false,
+						required: true,
+					},
+					email: {
+						type: String,
+						unique: true,
+						required: true,
+						validate: {
+							validator: (v) => {
+								// Super simple email regex: https://stackoverflow.com/a/4964763/7028187
+								return /^.+@.{2,}\..{2,}$/.test(v);
+							},
+							message: (props) => `${props.value} is not a valid email!`,
+						},
+					},
+					posts: [
+						{
+							type: "ObjectId",
+							ref: "Post",
+							validateExistance: true,
+						},
+					],
+					createdAtUTC: {
+						type: Date,
+						required: true,
+					},
+				},
+			},
+			{
+				name: "preandpost",
+				alias: "PreAndPost",
+				schema: {
+					someField: {
+						type: String,
+						required: true,
+					},
+					someOtherField: {
+						type: String,
+						required: true,
+					},
+					newField: {
+						type: String,
+					},
+				},
+				pre: {
+					save: function (next) {
+						this.someField = "not a dummy!";
+						next();
+					},
+				},
+				post: {
+					save: function (doc) {
+						hasHitPostSaveHook = true;
+					},
+				},
+			},
+		],
+		useNameAndAlias: true,
+	});
 
-  fastify.post("/", async ({ body }, reply) => {
-    const { username, password, email } = body;
-    const createdAtUTC = new Date();
-    const account = new fastify.mongoose.Account({
-      username,
-      password,
-      email,
-      createdAtUTC
-    });
-    await account.save();
-    return await fastify.mongoose.Account.findOne({ email });
-  });
+	fastify.post("/", async ({ body }, reply) => {
+		const { username, password, email } = body;
+		const createdAtUTC = new Date();
+		const account = new fastify.mongoose.Account({
+			username,
+			password,
+			email,
+			createdAtUTC,
+		});
+		await account.save();
+		return await fastify.mongoose.Account.findOne({ email });
+	});
 
-  fastify.patch("/", async ({ body }, reply) => {
-    const { title, content, author } = body;
-    const post = new fastify.mongoose.Post({
-      title,
-      content,
-      author
-    });
-    await post.save();
-    const foundPost = await fastify.mongoose.Post.findById(post._id);
-    return foundPost.toObject({ virtuals: true });
-  });
+	fastify.patch("/", async ({ body }, reply) => {
+		const { title, content, author } = body;
+		const post = new fastify.mongoose.Post({
+			title,
+			content,
+			author,
+		});
+		await post.save();
+		const foundPost = await fastify.mongoose.Post.findById(post._id);
+		return foundPost.toObject({ virtuals: true });
+	});
 
-  try {
-    await fastify.ready();
-    test.ok(fastify.mongoose.instance);
-    test.ok(fastify.mongoose.Account);
+	fastify.get("/", async (request, reply) => {
+		const preandpost = new fastify.mongoose.PreAndPost({
+			someField: "dummy",
+			someOtherField: "smartie",
+		});
+		await preandpost.save();
+		const foundPost = await fastify.mongoose.PreAndPost.findById(
+			preandpost._id
+		);
+		return foundPost.toObject({ virtuals: true });
+	});
 
-    const testEmail = `${(+new Date()).toString(36).slice(-5)}@example.com`;
+	try {
+		await fastify.ready();
+		test.ok(fastify.mongoose.instance);
+		test.ok(fastify.mongoose.Account);
 
-    let { statusCode, payload } = await fastify.inject({
-      method: "POST",
-      url: "/",
-      payload: {
-        username: "test",
-        password: "pass",
-        email: testEmail
-      }
-    });
+		const testEmail = `${(+new Date()).toString(36).slice(-5)}@example.com`;
 
-    const { username, password, email, _id } = JSON.parse(payload);
-    test.strictEqual(statusCode, 200);
-    test.strictEqual(username, "test");
-    test.strictEqual(password, undefined);
-    test.strictEqual(email, testEmail);
+		let { statusCode, payload } = await fastify.inject({
+			method: "POST",
+			url: "/",
+			payload: {
+				username: "test",
+				password: "pass",
+				email: testEmail,
+			},
+		});
 
-    ({ statusCode, payload } = await fastify.inject({
-      method: "PATCH",
-      url: "/",
-      payload: { author: _id, title: "Hello World", content: "foo bar" }
-    }));
+		const { username, password, email, _id } = JSON.parse(payload);
+		test.strictEqual(statusCode, 200);
+		test.strictEqual(username, "test");
+		test.strictEqual(password, undefined);
+		test.strictEqual(email, testEmail);
 
-    const { title, fullTitle, content, author } = JSON.parse(payload);
-    test.strictEqual(fullTitle, "Title: Hello World");
-    test.strictEqual(title, "Hello World");
-    test.strictEqual(content, "foo bar");
-    test.strictEqual(author, _id);
+		({ statusCode, payload } = await fastify.inject({
+			method: "PATCH",
+			url: "/",
+			payload: { author: _id, title: "Hello World", content: "foo bar" },
+		}));
 
-    test.ok(fastifyMongoose.decorator().instance);
-    test.ok(fastifyMongoose.decorator().Account);
-  } catch (e) {
-    test.fail("Fastify threw", e);
-  }
-  fastify.close();
+		const { title, fullTitle, content, author } = JSON.parse(payload);
+		test.strictEqual(fullTitle, "Title: Hello World");
+		test.strictEqual(title, "Hello World");
+		test.strictEqual(content, "foo bar");
+		test.strictEqual(author, _id);
+
+		({ payload } = await fastify.inject({
+			method: "GET",
+			url: "/",
+		}));
+
+		const { someField, someOtherField, newField } = JSON.parse(payload);
+		test.strictEqual(someField, "not a dummy!");
+		test.strictEqual(someOtherField, "smartie");
+		test.strictEqual(hasHitPostSaveHook, true);
+
+		test.ok(fastifyMongoose.decorator().instance);
+		test.ok(fastifyMongoose.decorator().Account);
+	} catch (e) {
+		test.fail("Fastify threw", e);
+	}
+	fastify.close();
 });


### PR DESCRIPTION
Hey @alex-ppg thanks for the plugin. I've been using it but ran into a couple things that weren't included and the big one was i didn't know how to add pre and post hooks directly in my schema. Turned out to be pretty simple! I added the code and included a test. This is just a simple working version and I was hoping to discuss this further get it merged.

(Other feature I wanted was the ability to add compound indexes)